### PR TITLE
do not output null descriptions

### DIFF
--- a/util/interface.js
+++ b/util/interface.js
@@ -41,10 +41,9 @@ type ${name} = ${possibleTypes};`;
 
 const typeNameDeclaration = '__typename: string;\n'
 
-const generateInterfaceDeclaration = (description, declaration, fields, additionalInfo, isInput) => `${additionalInfo}${description && `/*
+const generateInterfaceDeclaration = (description, declaration, fields, additionalInfo, isInput) => `${additionalInfo}${description ? `/*
   description: ${description}
-*/`}
-type ${declaration} = {
+*/\n` : ''}type ${declaration} = {
   ${isInput ? '' : typeNameDeclaration}${fields}
 }`;
 

--- a/util/module.js
+++ b/util/module.js
@@ -3,7 +3,8 @@
 const fileIO = require('./fileIO');
 
 const generateModule = (moduleName, interfaces) => {
-  return `// graphql flow definitions
+  return `// @flow
+// graphql flow definitions
 ${interfaces}
 `
 };

--- a/util/module.js
+++ b/util/module.js
@@ -3,7 +3,7 @@
 const fileIO = require('./fileIO');
 
 const generateModule = (moduleName, interfaces) => {
-  return `// graphql typescript definitions
+  return `// graphql flow definitions
 ${interfaces}
 `
 };


### PR DESCRIPTION
before:
```
null
type Query = {
  __typename: string;
  node?: Node;
  viewer?: Viewer;
  floor?: Floor;
  primaryAssignmentPlan?: AssignmentPlan;
}
```

after:
```
type Query = {
  __typename: string;
  node?: Node;
  viewer?: Viewer;
  floor?: Floor;
  primaryAssignmentPlan?: AssignmentPlan;
}
```
