### PR TITLE
Adds Description to the inline docs &  greens the tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const interfaceUtils = require('./util/interface');
 const moduleUtils = require('./util/module')
 
 program
-  .version('0.2.1')
+  .version('0.3.0')
   .usage('[options] <schema.json>')
   .option('-o --output-file [outputFile]', 'name for ouput file, defaults to graphql-export.flow.js', 'graphql-export.flow.js')
   .option('-m --module-name [moduleName]', 'name for the export module, defaults to "GQL"', 'GQL')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql2flow",
-  "version": "0.1.2",
+  "version": "0.3.0",
   "description": "Convert a GraphQL Schema to a Flowtype definition",
   "main": "index.js",
   "dependencies": {

--- a/test/data/expectedEnum.js
+++ b/test/data/expectedEnum.js
@@ -1,35 +1,25 @@
-module.exports = `// graphql typescript definitions
-
-declare module GQL {
-  export interface GraphQLResponseRoot {
-    data?: IQuery;
-    errors?: Array<GraphQLResponseError>;
-  }
-
-  export interface GraphQLResponseError {
-    message: string;            // Required for all errors
-    locations?: Array<GraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
-  }
-
-  export interface GraphQLResponseErrorLocation {
-    line: number;
-    column: number;
-  }
-
-  /*
-    description: null
-  */
-  export interface IQuery {
-    __typename: string;
-    colorEnum: IColorEnum;
-  }
-
-  /*
-    description: null
-  */
-  export type IColorEnum = "RED" | "GREEN" | "BLUE";
+// @flow
+// graphql flow definitions
+export type GraphQLResponseRoot = {
+  data?: Query;
+  errors?: Array<GraphQLResponseError>;
 }
 
-export default GQL;
-`
+export type GraphQLResponseError = {
+  message: string;            // Required for all errors
+  locations?: Array<GraphQLResponseErrorLocation>;
+  [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+}
+
+export type GraphQLResponseErrorLocation = {
+  line: number;
+  column: number;
+}
+
+export type Query = {
+  __typename: string;
+  colorEnum?: ColorEnum;
+}
+
+null
+export type ColorEnum = "RED" | "GREEN" | "BLUE";

--- a/test/data/expectedEnumInterfaces.js
+++ b/test/data/expectedEnumInterfaces.js
@@ -1,28 +1,23 @@
-module.exports = `  export interface GraphQLResponseRoot {
-    data?: IQuery;
-    errors?: Array<GraphQLResponseError>;
-  }
+export type GraphQLResponseRoot = {
+  data?: Query;
+  errors?: Array<GraphQLResponseError>;
+}
 
-  export interface GraphQLResponseError {
-    message: string;            // Required for all errors
-    locations?: Array<GraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
-  }
+export type GraphQLResponseError = {
+  message: string;            // Required for all errors
+  locations?: Array<GraphQLResponseErrorLocation>;
+  [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+}
 
-  export interface GraphQLResponseErrorLocation {
-    line: number;
-    column: number;
-  }
+export type GraphQLResponseErrorLocation = {
+  line: number;
+  column: number;
+}
 
-  /*
-    description: null
-  */
-  export interface IQuery {
-    __typename: string;
-    colorEnum: IColorEnum;
-  }
+export type Query = {
+  __typename: string;
+  colorEnum?: ColorEnum;
+}
 
-  /*
-    description: null
-  */
-  export type IColorEnum = "RED" | "GREEN" | "BLUE";`
+null
+export type ColorEnum = "RED" | "GREEN" | "BLUE";

--- a/test/data/expectedInterfaces.js
+++ b/test/data/expectedInterfaces.js
@@ -1,635 +1,1037 @@
-module.exports = `  export interface GraphQLResponseRoot {
-    data?: IRoot;
-    errors?: Array<GraphQLResponseError>;
-  }
+export type GraphQLResponseRoot = {
+  data?: Root;
+  errors?: Array<GraphQLResponseError>;
+}
 
-  export interface GraphQLResponseError {
-    message: string;            // Required for all errors
-    locations?: Array<GraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
-  }
+export type GraphQLResponseError = {
+  message: string;            // Required for all errors
+  locations?: Array<GraphQLResponseErrorLocation>;
+  [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+}
 
-  export interface GraphQLResponseErrorLocation {
-    line: number;
-    column: number;
-  }
+export type GraphQLResponseErrorLocation = {
+  line: number;
+  column: number;
+}
 
-  /*
-    description: null
-  */
-  export interface IRoot {
-    __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    person: IPerson;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
-  }
+export type Root = {
+  __typename: string;
+  allFilms?: FilmsConnection;
+  film?: Film;
+  allPeople?: PeopleConnection;
+  person?: Person;
+  allPlanets?: PlanetsConnection;
+  planet?: Planet;
+  allSpecies?: SpeciesConnection;
+  species?: Species;
+  allStarships?: StarshipsConnection;
+  starship?: Starship;
+  allVehicles?: VehiclesConnection;
+  vehicle?: Vehicle;
+  /** Fetches an object given its ID */
+  node?: Node;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: Information about pagination in a connection.
-  */
-  export interface IPageInfo {
-    __typename: string;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
-  }
+/**
+  description: Information about pagination in a connection.
+*/
+export type PageInfo = {
+  __typename: string;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: boolean;
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: boolean;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: string;
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: string;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A single film.
-  */
-  export interface IFilm {
-    __typename: string;
-    title: string;
-    episodeID: any;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A single film.
+*/
+export type Film = {
+  __typename: string;
+  /** The title of this film. */
+  title?: string;
+  /** The episode number of this film. */
+  episodeID?: number;
+  /** The opening paragraphs at the beginning of this film. */
+  openingCrawl?: string;
+  /** The name of the director of this film. */
+  director?: string;
+  /** The name(s) of the producer(s) of this film. */
+  producers?: Array<string>;
+  /** The ISO 8601 date format of film release at original creator country. */
+  releaseDate?: string;
+  speciesConnection?: FilmSpeciesConnection;
+  starshipConnection?: FilmStarshipsConnection;
+  vehicleConnection?: FilmVehiclesConnection;
+  characterConnection?: FilmCharactersConnection;
+  planetConnection?: FilmPlanetsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: An object with an ID
-  */
-  export type Node = IPlanet | ISpecies | IStarship | IVehicle | IPerson | IFilm;
+/**
+  description: An object with an ID
+*/
+export type Node = Planet | Species | Starship | Vehicle | Person | Film;
 
-  /*
-    description: An object with an ID
-  */
-  export interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IPerson, IFilm {
-    __typename: string;
-    id: string;
-  }
-
-  /*
-    description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
+/**
+  description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
 0 ABY.
-  */
-  export interface IPlanet {
-    __typename: string;
-    name: string;
-    diameter: any;
-    rotationPeriod: any;
-    orbitalPeriod: any;
-    gravity: string;
-    population: any;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+*/
+export type Planet = {
+  __typename: string;
+  /** The name of this planet. */
+  name?: string;
+  /** The diameter of this planet in kilometers. */
+  diameter?: number;
+  /** The number of standard hours it takes for this planet to complete a single
+rotation on its axis. */
+  rotationPeriod?: number;
+  /** The number of standard days it takes for this planet to complete a single orbit
+of its local star. */
+  orbitalPeriod?: number;
+  /** A number denoting the gravity of this planet, where "1" is normal or 1 standard
+G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs. */
+  gravity?: string;
+  /** The average population of sentient beings inhabiting this planet. */
+  population?: number;
+  /** The climates of this planet. */
+  climates?: Array<string>;
+  /** The terrains of this planet. */
+  terrains?: Array<string>;
+  /** The percentage of the planet surface that is naturally occuring water or bodies
+of water. */
+  surfaceWater?: number;
+  residentConnection?: PlanetResidentsConnection;
+  filmConnection?: PlanetFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetResidentsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: any;
-    residents: Array<IPerson>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetResidentsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetResidentsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  residents?: Array<Person>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetResidentsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PlanetResidentsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: An individual person or character within the Star Wars universe.
-  */
-  export interface IPerson {
-    __typename: string;
-    name: string;
-    birthYear: string;
-    eyeColor: string;
-    gender: string;
-    hairColor: string;
-    height: any;
-    mass: any;
-    skinColor: string;
-    homeworld: IPlanet;
-    filmConnection: IPersonFilmsConnection;
-    species: ISpecies;
-    starshipConnection: IPersonStarshipsConnection;
-    vehicleConnection: IPersonVehiclesConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: An individual person or character within the Star Wars universe.
+*/
+export type Person = {
+  __typename: string;
+  /** The name of this person. */
+  name?: string;
+  /** The birth year of the person, using the in-universe standard of BBY or ABY -
+Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
+a battle that occurs at the end of Star Wars episode IV: A New Hope. */
+  birthYear?: string;
+  /** The eye color of this person. Will be "unknown" if not known or "n/a" if the
+person does not have an eye. */
+  eyeColor?: string;
+  /** The gender of this person. Either "Male", "Female" or "unknown",
+"n/a" if the person does not have a gender. */
+  gender?: string;
+  /** The hair color of this person. Will be "unknown" if not known or "n/a" if the
+person does not have hair. */
+  hairColor?: string;
+  /** The height of the person in centimeters. */
+  height?: number;
+  /** The mass of the person in kilograms. */
+  mass?: number;
+  /** The skin color of this person. */
+  skinColor?: string;
+  /** A planet that this person was born on or inhabits. */
+  homeworld?: Planet;
+  filmConnection?: PersonFilmsConnection;
+  /** The species that this person belongs to, or null if unknown. */
+  species?: Species;
+  starshipConnection?: PersonStarshipsConnection;
+  vehicleConnection?: PersonVehiclesConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PersonFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PersonFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A type of person or character within the Star Wars Universe.
-  */
-  export interface ISpecies {
-    __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: any;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A type of person or character within the Star Wars Universe.
+*/
+export type Species = {
+  __typename: string;
+  /** The name of this species. */
+  name?: string;
+  /** The classification of this species, such as "mammal" or "reptile". */
+  classification?: string;
+  /** The designation of this species, such as "sentient". */
+  designation?: string;
+  /** The average height of this species in centimeters. */
+  averageHeight?: number;
+  /** The average lifespan of this species in years. */
+  averageLifespan?: number;
+  /** Common eye colors for this species, null if this species does not typically
+have eyes. */
+  eyeColors?: Array<string>;
+  /** Common hair colors for this species, null if this species does not typically
+have hair. */
+  hairColors?: Array<string>;
+  /** Common skin colors for this species, null if this species does not typically
+have skin. */
+  skinColors?: Array<string>;
+  /** The language commonly spoken by this species. */
+  language?: string;
+  /** A planet that this species originates from. */
+  homeworld?: Planet;
+  personConnection?: SpeciesPeopleConnection;
+  filmConnection?: SpeciesFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: any;
-    people: Array<IPerson>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesPeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesPeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  people?: Array<Person>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesPeopleEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesPeopleEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PersonStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PersonStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A single transport craft that has hyperdrive capability.
-  */
-  export interface IStarship {
-    __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    hyperdriveRating: number;
-    MGLT: any;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A single transport craft that has hyperdrive capability.
+*/
+export type Starship = {
+  __typename: string;
+  /** The name of this starship. The common name, such as "Death Star". */
+  name?: string;
+  /** The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+Orbital Battle Station". */
+  model?: string;
+  /** The class of this starship, such as "Starfighter" or "Deep Space Mobile
+Battlestation" */
+  starshipClass?: string;
+  /** The manufacturers of this starship. */
+  manufacturers?: Array<string>;
+  /** The cost of this starship new, in galactic credits. */
+  costInCredits?: number;
+  /** The length of this starship in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this starship. */
+  crew?: string;
+  /** The number of non-essential people this starship can transport. */
+  passengers?: string;
+  /** The maximum speed of this starship in atmosphere. null if this starship is
+incapable of atmosphering flight. */
+  maxAtmospheringSpeed?: number;
+  /** The class of this starships hyperdrive. */
+  hyperdriveRating?: number;
+  /** The Maximum number of Megalights this starship can travel in a standard hour.
+A "Megalight" is a standard unit of distance and has never been defined before
+within the Star Wars universe. This figure is only really useful for measuring
+the difference in speed of starships. We can assume it is similar to AU, the
+distance between our Sun (Sol) and Earth. */
+  MGLT?: number;
+  /** The maximum number of kilograms that this starship can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this starship can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: StarshipPilotsConnection;
+  filmConnection?: StarshipFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipPilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: any;
-    pilots: Array<IPerson>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipPilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipPilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  pilots?: Array<Person>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipPilotsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type StarshipPilotsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type StarshipFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PersonVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PersonVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A single transport craft that does not have hyperdrive capability
-  */
-  export interface IVehicle {
-    __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: any;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    cargoCapacity: any;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A single transport craft that does not have hyperdrive capability
+*/
+export type Vehicle = {
+  __typename: string;
+  /** The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+bike". */
+  name?: string;
+  /** The model or official name of this vehicle. Such as "All-Terrain Attack
+Transport". */
+  model?: string;
+  /** The class of this vehicle, such as "Wheeled" or "Repulsorcraft". */
+  vehicleClass?: string;
+  /** The manufacturers of this vehicle. */
+  manufacturers?: Array<string>;
+  /** The cost of this vehicle new, in Galactic Credits. */
+  costInCredits?: number;
+  /** The length of this vehicle in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this vehicle. */
+  crew?: string;
+  /** The number of non-essential people this vehicle can transport. */
+  passengers?: string;
+  /** The maximum speed of this vehicle in atmosphere. */
+  maxAtmospheringSpeed?: number;
+  /** The maximum number of kilograms that this vehicle can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this vehicle can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: VehiclePilotsConnection;
+  filmConnection?: VehicleFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclePilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: any;
-    pilots: Array<IPerson>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclePilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclePilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  pilots?: Array<Person>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclePilotsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type VehiclePilotsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehicleFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type VehicleFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehicleFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehicleFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type VehicleFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PlanetFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmSpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmSpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmSpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmSpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmSpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmCharactersConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: any;
-    characters: Array<IPerson>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmCharactersConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmCharactersEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  characters?: Array<Person>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmCharactersEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmCharactersEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmPlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmPlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmPlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: any;
-    people: Array<IPerson>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  people?: Array<Person>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPeopleEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PeopleEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type StarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }`
+/**
+  description: An edge in a connection.
+*/
+export type VehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}

--- a/test/data/expectedModule.js
+++ b/test/data/expectedModule.js
@@ -1,642 +1,1039 @@
-module.exports = `// graphql typescript definitions
-
-declare module GQL {
-  export interface GraphQLResponseRoot {
-    data?: IRoot;
-    errors?: Array<GraphQLResponseError>;
-  }
-
-  export interface GraphQLResponseError {
-    message: string;            // Required for all errors
-    locations?: Array<GraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
-  }
-
-  export interface GraphQLResponseErrorLocation {
-    line: number;
-    column: number;
-  }
-
-  /*
-    description: null
-  */
-  export interface IRoot {
-    __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    person: IPerson;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: Information about pagination in a connection.
-  */
-  export interface IPageInfo {
-    __typename: string;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A single film.
-  */
-  export interface IFilm {
-    __typename: string;
-    title: string;
-    episodeID: any;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: An object with an ID
-  */
-  export type Node = IPlanet | ISpecies | IStarship | IVehicle | IPerson | IFilm;
-
-  /*
-    description: An object with an ID
-  */
-  export interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IPerson, IFilm {
-    __typename: string;
-    id: string;
-  }
-
-  /*
-    description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
-0 ABY.
-  */
-  export interface IPlanet {
-    __typename: string;
-    name: string;
-    diameter: any;
-    rotationPeriod: any;
-    orbitalPeriod: any;
-    gravity: string;
-    population: any;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetResidentsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: any;
-    residents: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetResidentsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: An individual person or character within the Star Wars universe.
-  */
-  export interface IPerson {
-    __typename: string;
-    name: string;
-    birthYear: string;
-    eyeColor: string;
-    gender: string;
-    hairColor: string;
-    height: any;
-    mass: any;
-    skinColor: string;
-    homeworld: IPlanet;
-    filmConnection: IPersonFilmsConnection;
-    species: ISpecies;
-    starshipConnection: IPersonStarshipsConnection;
-    vehicleConnection: IPersonVehiclesConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A type of person or character within the Star Wars Universe.
-  */
-  export interface ISpecies {
-    __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: any;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: any;
-    people: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesPeopleEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A single transport craft that has hyperdrive capability.
-  */
-  export interface IStarship {
-    __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    hyperdriveRating: number;
-    MGLT: any;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipPilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: any;
-    pilots: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipPilotsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
-
-  /*
-    description: A single transport craft that does not have hyperdrive capability
-  */
-  export interface IVehicle {
-    __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: any;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    cargoCapacity: any;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclePilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: any;
-    pilots: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclePilotsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehicleFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehicleFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmSpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmSpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmCharactersConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: any;
-    characters: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmCharactersEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: any;
-    people: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPeopleEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
+// @flow
+// graphql flow definitions
+export type GraphQLResponseRoot = {
+  data?: Root;
+  errors?: Array<GraphQLResponseError>;
 }
 
-export default GQL;
-`
+export type GraphQLResponseError = {
+  message: string;            // Required for all errors
+  locations?: Array<GraphQLResponseErrorLocation>;
+  [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+}
+
+export type GraphQLResponseErrorLocation = {
+  line: number;
+  column: number;
+}
+
+export type Root = {
+  __typename: string;
+  allFilms?: FilmsConnection;
+  film?: Film;
+  allPeople?: PeopleConnection;
+  person?: Person;
+  allPlanets?: PlanetsConnection;
+  planet?: Planet;
+  allSpecies?: SpeciesConnection;
+  species?: Species;
+  allStarships?: StarshipsConnection;
+  starship?: Starship;
+  allVehicles?: VehiclesConnection;
+  vehicle?: Vehicle;
+  /** Fetches an object given its ID */
+  node?: Node;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: Information about pagination in a connection.
+*/
+export type PageInfo = {
+  __typename: string;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: boolean;
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: boolean;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: string;
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: string;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single film.
+*/
+export type Film = {
+  __typename: string;
+  /** The title of this film. */
+  title?: string;
+  /** The episode number of this film. */
+  episodeID?: number;
+  /** The opening paragraphs at the beginning of this film. */
+  openingCrawl?: string;
+  /** The name of the director of this film. */
+  director?: string;
+  /** The name(s) of the producer(s) of this film. */
+  producers?: Array<string>;
+  /** The ISO 8601 date format of film release at original creator country. */
+  releaseDate?: string;
+  speciesConnection?: FilmSpeciesConnection;
+  starshipConnection?: FilmStarshipsConnection;
+  vehicleConnection?: FilmVehiclesConnection;
+  characterConnection?: FilmCharactersConnection;
+  planetConnection?: FilmPlanetsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: An object with an ID
+*/
+export type Node = Planet | Species | Starship | Vehicle | Person | Film;
+
+/**
+  description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
+0 ABY.
+*/
+export type Planet = {
+  __typename: string;
+  /** The name of this planet. */
+  name?: string;
+  /** The diameter of this planet in kilometers. */
+  diameter?: number;
+  /** The number of standard hours it takes for this planet to complete a single
+rotation on its axis. */
+  rotationPeriod?: number;
+  /** The number of standard days it takes for this planet to complete a single orbit
+of its local star. */
+  orbitalPeriod?: number;
+  /** A number denoting the gravity of this planet, where "1" is normal or 1 standard
+G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs. */
+  gravity?: string;
+  /** The average population of sentient beings inhabiting this planet. */
+  population?: number;
+  /** The climates of this planet. */
+  climates?: Array<string>;
+  /** The terrains of this planet. */
+  terrains?: Array<string>;
+  /** The percentage of the planet surface that is naturally occuring water or bodies
+of water. */
+  surfaceWater?: number;
+  residentConnection?: PlanetResidentsConnection;
+  filmConnection?: PlanetFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetResidentsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetResidentsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  residents?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetResidentsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: An individual person or character within the Star Wars universe.
+*/
+export type Person = {
+  __typename: string;
+  /** The name of this person. */
+  name?: string;
+  /** The birth year of the person, using the in-universe standard of BBY or ABY -
+Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
+a battle that occurs at the end of Star Wars episode IV: A New Hope. */
+  birthYear?: string;
+  /** The eye color of this person. Will be "unknown" if not known or "n/a" if the
+person does not have an eye. */
+  eyeColor?: string;
+  /** The gender of this person. Either "Male", "Female" or "unknown",
+"n/a" if the person does not have a gender. */
+  gender?: string;
+  /** The hair color of this person. Will be "unknown" if not known or "n/a" if the
+person does not have hair. */
+  hairColor?: string;
+  /** The height of the person in centimeters. */
+  height?: number;
+  /** The mass of the person in kilograms. */
+  mass?: number;
+  /** The skin color of this person. */
+  skinColor?: string;
+  /** A planet that this person was born on or inhabits. */
+  homeworld?: Planet;
+  filmConnection?: PersonFilmsConnection;
+  /** The species that this person belongs to, or null if unknown. */
+  species?: Species;
+  starshipConnection?: PersonStarshipsConnection;
+  vehicleConnection?: PersonVehiclesConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A type of person or character within the Star Wars Universe.
+*/
+export type Species = {
+  __typename: string;
+  /** The name of this species. */
+  name?: string;
+  /** The classification of this species, such as "mammal" or "reptile". */
+  classification?: string;
+  /** The designation of this species, such as "sentient". */
+  designation?: string;
+  /** The average height of this species in centimeters. */
+  averageHeight?: number;
+  /** The average lifespan of this species in years. */
+  averageLifespan?: number;
+  /** Common eye colors for this species, null if this species does not typically
+have eyes. */
+  eyeColors?: Array<string>;
+  /** Common hair colors for this species, null if this species does not typically
+have hair. */
+  hairColors?: Array<string>;
+  /** Common skin colors for this species, null if this species does not typically
+have skin. */
+  skinColors?: Array<string>;
+  /** The language commonly spoken by this species. */
+  language?: string;
+  /** A planet that this species originates from. */
+  homeworld?: Planet;
+  personConnection?: SpeciesPeopleConnection;
+  filmConnection?: SpeciesFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesPeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesPeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  people?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesPeopleEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single transport craft that has hyperdrive capability.
+*/
+export type Starship = {
+  __typename: string;
+  /** The name of this starship. The common name, such as "Death Star". */
+  name?: string;
+  /** The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+Orbital Battle Station". */
+  model?: string;
+  /** The class of this starship, such as "Starfighter" or "Deep Space Mobile
+Battlestation" */
+  starshipClass?: string;
+  /** The manufacturers of this starship. */
+  manufacturers?: Array<string>;
+  /** The cost of this starship new, in galactic credits. */
+  costInCredits?: number;
+  /** The length of this starship in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this starship. */
+  crew?: string;
+  /** The number of non-essential people this starship can transport. */
+  passengers?: string;
+  /** The maximum speed of this starship in atmosphere. null if this starship is
+incapable of atmosphering flight. */
+  maxAtmospheringSpeed?: number;
+  /** The class of this starships hyperdrive. */
+  hyperdriveRating?: number;
+  /** The Maximum number of Megalights this starship can travel in a standard hour.
+A "Megalight" is a standard unit of distance and has never been defined before
+within the Star Wars universe. This figure is only really useful for measuring
+the difference in speed of starships. We can assume it is similar to AU, the
+distance between our Sun (Sol) and Earth. */
+  MGLT?: number;
+  /** The maximum number of kilograms that this starship can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this starship can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: StarshipPilotsConnection;
+  filmConnection?: StarshipFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipPilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipPilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  pilots?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipPilotsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single transport craft that does not have hyperdrive capability
+*/
+export type Vehicle = {
+  __typename: string;
+  /** The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+bike". */
+  name?: string;
+  /** The model or official name of this vehicle. Such as "All-Terrain Attack
+Transport". */
+  model?: string;
+  /** The class of this vehicle, such as "Wheeled" or "Repulsorcraft". */
+  vehicleClass?: string;
+  /** The manufacturers of this vehicle. */
+  manufacturers?: Array<string>;
+  /** The cost of this vehicle new, in Galactic Credits. */
+  costInCredits?: number;
+  /** The length of this vehicle in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this vehicle. */
+  crew?: string;
+  /** The number of non-essential people this vehicle can transport. */
+  passengers?: string;
+  /** The maximum speed of this vehicle in atmosphere. */
+  maxAtmospheringSpeed?: number;
+  /** The maximum number of kilograms that this vehicle can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this vehicle can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: VehiclePilotsConnection;
+  filmConnection?: VehicleFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclePilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclePilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  pilots?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehiclePilotsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehicleFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehicleFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehicleFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmSpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmSpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmSpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmCharactersConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmCharactersEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  characters?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmCharactersEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmPlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmPlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmPlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  people?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PeopleEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}

--- a/test/data/ignoredPerson.js
+++ b/test/data/ignoredPerson.js
@@ -1,606 +1,943 @@
-module.exports = `// graphql typescript definitions
-
-declare module StarWars {
-  export interface GraphQLResponseRoot {
-    data?: IRoot;
-    errors?: Array<GraphQLResponseError>;
-  }
-
-  export interface GraphQLResponseError {
-    message: string;            // Required for all errors
-    locations?: Array<GraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
-  }
-
-  export interface GraphQLResponseErrorLocation {
-    line: number;
-    column: number;
-  }
-
-  /*
-    description: null
-  */
-  export interface IRoot {
-    __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: Information about pagination in a connection.
-  */
-  export interface IPageInfo {
-    __typename: string;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A single film.
-  */
-  export interface IFilm {
-    __typename: string;
-    title: string;
-    episodeID: any;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: An object with an ID
-  */
-  export type Node = IPlanet | ISpecies | IStarship | IVehicle | IFilm;
-
-  /*
-    description: An object with an ID
-  */
-  export interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IFilm {
-    __typename: string;
-    id: string;
-  }
-
-  /*
-    description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
-0 ABY.
-  */
-  export interface IPlanet {
-    __typename: string;
-    name: string;
-    diameter: any;
-    rotationPeriod: any;
-    orbitalPeriod: any;
-    gravity: string;
-    population: any;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetResidentsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: any;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetResidentsEdge {
-    __typename: string;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A type of person or character within the Star Wars Universe.
-  */
-  export interface ISpecies {
-    __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: any;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: any;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesPeopleEdge {
-    __typename: string;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A single transport craft that has hyperdrive capability.
-  */
-  export interface IStarship {
-    __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    hyperdriveRating: number;
-    MGLT: any;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipPilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: any;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipPilotsEdge {
-    __typename: string;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
-
-  /*
-    description: A single transport craft that does not have hyperdrive capability
-  */
-  export interface IVehicle {
-    __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: any;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    cargoCapacity: any;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclePilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: any;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclePilotsEdge {
-    __typename: string;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehicleFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehicleFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmSpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmSpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmCharactersConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: any;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmCharactersEdge {
-    __typename: string;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: any;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPeopleEdge {
-    __typename: string;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
+// @flow
+// graphql flow definitions
+export type GraphQLResponseRoot = {
+  data?: Root;
+  errors?: Array<GraphQLResponseError>;
 }
 
-export default StarWars;
-`
+export type GraphQLResponseError = {
+  message: string;            // Required for all errors
+  locations?: Array<GraphQLResponseErrorLocation>;
+  [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+}
+
+export type GraphQLResponseErrorLocation = {
+  line: number;
+  column: number;
+}
+
+export type Root = {
+  __typename: string;
+  allFilms?: FilmsConnection;
+  film?: Film;
+  allPeople?: PeopleConnection;
+  allPlanets?: PlanetsConnection;
+  planet?: Planet;
+  allSpecies?: SpeciesConnection;
+  species?: Species;
+  allStarships?: StarshipsConnection;
+  starship?: Starship;
+  allVehicles?: VehiclesConnection;
+  vehicle?: Vehicle;
+  /** Fetches an object given its ID */
+  node?: Node;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: Information about pagination in a connection.
+*/
+export type PageInfo = {
+  __typename: string;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: boolean;
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: boolean;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: string;
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: string;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single film.
+*/
+export type Film = {
+  __typename: string;
+  /** The title of this film. */
+  title?: string;
+  /** The episode number of this film. */
+  episodeID?: number;
+  /** The opening paragraphs at the beginning of this film. */
+  openingCrawl?: string;
+  /** The name of the director of this film. */
+  director?: string;
+  /** The name(s) of the producer(s) of this film. */
+  producers?: Array<string>;
+  /** The ISO 8601 date format of film release at original creator country. */
+  releaseDate?: string;
+  speciesConnection?: FilmSpeciesConnection;
+  starshipConnection?: FilmStarshipsConnection;
+  vehicleConnection?: FilmVehiclesConnection;
+  characterConnection?: FilmCharactersConnection;
+  planetConnection?: FilmPlanetsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: An object with an ID
+*/
+export type Node = Planet | Species | Starship | Vehicle | Film;
+
+/**
+  description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
+0 ABY.
+*/
+export type Planet = {
+  __typename: string;
+  /** The name of this planet. */
+  name?: string;
+  /** The diameter of this planet in kilometers. */
+  diameter?: number;
+  /** The number of standard hours it takes for this planet to complete a single
+rotation on its axis. */
+  rotationPeriod?: number;
+  /** The number of standard days it takes for this planet to complete a single orbit
+of its local star. */
+  orbitalPeriod?: number;
+  /** A number denoting the gravity of this planet, where "1" is normal or 1 standard
+G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs. */
+  gravity?: string;
+  /** The average population of sentient beings inhabiting this planet. */
+  population?: number;
+  /** The climates of this planet. */
+  climates?: Array<string>;
+  /** The terrains of this planet. */
+  terrains?: Array<string>;
+  /** The percentage of the planet surface that is naturally occuring water or bodies
+of water. */
+  surfaceWater?: number;
+  residentConnection?: PlanetResidentsConnection;
+  filmConnection?: PlanetFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetResidentsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetResidentsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetResidentsEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A type of person or character within the Star Wars Universe.
+*/
+export type Species = {
+  __typename: string;
+  /** The name of this species. */
+  name?: string;
+  /** The classification of this species, such as "mammal" or "reptile". */
+  classification?: string;
+  /** The designation of this species, such as "sentient". */
+  designation?: string;
+  /** The average height of this species in centimeters. */
+  averageHeight?: number;
+  /** The average lifespan of this species in years. */
+  averageLifespan?: number;
+  /** Common eye colors for this species, null if this species does not typically
+have eyes. */
+  eyeColors?: Array<string>;
+  /** Common hair colors for this species, null if this species does not typically
+have hair. */
+  hairColors?: Array<string>;
+  /** Common skin colors for this species, null if this species does not typically
+have skin. */
+  skinColors?: Array<string>;
+  /** The language commonly spoken by this species. */
+  language?: string;
+  /** A planet that this species originates from. */
+  homeworld?: Planet;
+  personConnection?: SpeciesPeopleConnection;
+  filmConnection?: SpeciesFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesPeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesPeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesPeopleEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single transport craft that has hyperdrive capability.
+*/
+export type Starship = {
+  __typename: string;
+  /** The name of this starship. The common name, such as "Death Star". */
+  name?: string;
+  /** The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+Orbital Battle Station". */
+  model?: string;
+  /** The class of this starship, such as "Starfighter" or "Deep Space Mobile
+Battlestation" */
+  starshipClass?: string;
+  /** The manufacturers of this starship. */
+  manufacturers?: Array<string>;
+  /** The cost of this starship new, in galactic credits. */
+  costInCredits?: number;
+  /** The length of this starship in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this starship. */
+  crew?: string;
+  /** The number of non-essential people this starship can transport. */
+  passengers?: string;
+  /** The maximum speed of this starship in atmosphere. null if this starship is
+incapable of atmosphering flight. */
+  maxAtmospheringSpeed?: number;
+  /** The class of this starships hyperdrive. */
+  hyperdriveRating?: number;
+  /** The Maximum number of Megalights this starship can travel in a standard hour.
+A "Megalight" is a standard unit of distance and has never been defined before
+within the Star Wars universe. This figure is only really useful for measuring
+the difference in speed of starships. We can assume it is similar to AU, the
+distance between our Sun (Sol) and Earth. */
+  MGLT?: number;
+  /** The maximum number of kilograms that this starship can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this starship can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: StarshipPilotsConnection;
+  filmConnection?: StarshipFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipPilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipPilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipPilotsEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single transport craft that does not have hyperdrive capability
+*/
+export type Vehicle = {
+  __typename: string;
+  /** The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+bike". */
+  name?: string;
+  /** The model or official name of this vehicle. Such as "All-Terrain Attack
+Transport". */
+  model?: string;
+  /** The class of this vehicle, such as "Wheeled" or "Repulsorcraft". */
+  vehicleClass?: string;
+  /** The manufacturers of this vehicle. */
+  manufacturers?: Array<string>;
+  /** The cost of this vehicle new, in Galactic Credits. */
+  costInCredits?: number;
+  /** The length of this vehicle in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this vehicle. */
+  crew?: string;
+  /** The number of non-essential people this vehicle can transport. */
+  passengers?: string;
+  /** The maximum speed of this vehicle in atmosphere. */
+  maxAtmospheringSpeed?: number;
+  /** The maximum number of kilograms that this vehicle can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this vehicle can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: VehiclePilotsConnection;
+  filmConnection?: VehicleFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclePilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclePilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehiclePilotsEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehicleFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehicleFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehicleFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmSpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmSpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmSpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmCharactersConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmCharactersEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmCharactersEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmPlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmPlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmPlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PeopleEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}

--- a/test/data/ignoredPersonInterfaces.js
+++ b/test/data/ignoredPersonInterfaces.js
@@ -1,599 +1,941 @@
-module.exports = `  export interface GraphQLResponseRoot {
-    data?: IRoot;
-    errors?: Array<GraphQLResponseError>;
-  }
+export type GraphQLResponseRoot = {
+  data?: Root;
+  errors?: Array<GraphQLResponseError>;
+}
 
-  export interface GraphQLResponseError {
-    message: string;            // Required for all errors
-    locations?: Array<GraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
-  }
+export type GraphQLResponseError = {
+  message: string;            // Required for all errors
+  locations?: Array<GraphQLResponseErrorLocation>;
+  [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+}
 
-  export interface GraphQLResponseErrorLocation {
-    line: number;
-    column: number;
-  }
+export type GraphQLResponseErrorLocation = {
+  line: number;
+  column: number;
+}
 
-  /*
-    description: null
-  */
-  export interface IRoot {
-    __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
-  }
+export type Root = {
+  __typename: string;
+  allFilms?: FilmsConnection;
+  film?: Film;
+  allPeople?: PeopleConnection;
+  allPlanets?: PlanetsConnection;
+  planet?: Planet;
+  allSpecies?: SpeciesConnection;
+  species?: Species;
+  allStarships?: StarshipsConnection;
+  starship?: Starship;
+  allVehicles?: VehiclesConnection;
+  vehicle?: Vehicle;
+  /** Fetches an object given its ID */
+  node?: Node;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: Information about pagination in a connection.
-  */
-  export interface IPageInfo {
-    __typename: string;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
-  }
+/**
+  description: Information about pagination in a connection.
+*/
+export type PageInfo = {
+  __typename: string;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: boolean;
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: boolean;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: string;
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: string;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A single film.
-  */
-  export interface IFilm {
-    __typename: string;
-    title: string;
-    episodeID: any;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A single film.
+*/
+export type Film = {
+  __typename: string;
+  /** The title of this film. */
+  title?: string;
+  /** The episode number of this film. */
+  episodeID?: number;
+  /** The opening paragraphs at the beginning of this film. */
+  openingCrawl?: string;
+  /** The name of the director of this film. */
+  director?: string;
+  /** The name(s) of the producer(s) of this film. */
+  producers?: Array<string>;
+  /** The ISO 8601 date format of film release at original creator country. */
+  releaseDate?: string;
+  speciesConnection?: FilmSpeciesConnection;
+  starshipConnection?: FilmStarshipsConnection;
+  vehicleConnection?: FilmVehiclesConnection;
+  characterConnection?: FilmCharactersConnection;
+  planetConnection?: FilmPlanetsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: An object with an ID
-  */
-  export type Node = IPlanet | ISpecies | IStarship | IVehicle | IFilm;
+/**
+  description: An object with an ID
+*/
+export type Node = Planet | Species | Starship | Vehicle | Film;
 
-  /*
-    description: An object with an ID
-  */
-  export interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IFilm {
-    __typename: string;
-    id: string;
-  }
-
-  /*
-    description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
+/**
+  description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
 0 ABY.
-  */
-  export interface IPlanet {
-    __typename: string;
-    name: string;
-    diameter: any;
-    rotationPeriod: any;
-    orbitalPeriod: any;
-    gravity: string;
-    population: any;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+*/
+export type Planet = {
+  __typename: string;
+  /** The name of this planet. */
+  name?: string;
+  /** The diameter of this planet in kilometers. */
+  diameter?: number;
+  /** The number of standard hours it takes for this planet to complete a single
+rotation on its axis. */
+  rotationPeriod?: number;
+  /** The number of standard days it takes for this planet to complete a single orbit
+of its local star. */
+  orbitalPeriod?: number;
+  /** A number denoting the gravity of this planet, where "1" is normal or 1 standard
+G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs. */
+  gravity?: string;
+  /** The average population of sentient beings inhabiting this planet. */
+  population?: number;
+  /** The climates of this planet. */
+  climates?: Array<string>;
+  /** The terrains of this planet. */
+  terrains?: Array<string>;
+  /** The percentage of the planet surface that is naturally occuring water or bodies
+of water. */
+  surfaceWater?: number;
+  residentConnection?: PlanetResidentsConnection;
+  filmConnection?: PlanetFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetResidentsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: any;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetResidentsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetResidentsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetResidentsEdge {
-    __typename: string;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PlanetResidentsEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PersonFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PersonFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A type of person or character within the Star Wars Universe.
-  */
-  export interface ISpecies {
-    __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: any;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A type of person or character within the Star Wars Universe.
+*/
+export type Species = {
+  __typename: string;
+  /** The name of this species. */
+  name?: string;
+  /** The classification of this species, such as "mammal" or "reptile". */
+  classification?: string;
+  /** The designation of this species, such as "sentient". */
+  designation?: string;
+  /** The average height of this species in centimeters. */
+  averageHeight?: number;
+  /** The average lifespan of this species in years. */
+  averageLifespan?: number;
+  /** Common eye colors for this species, null if this species does not typically
+have eyes. */
+  eyeColors?: Array<string>;
+  /** Common hair colors for this species, null if this species does not typically
+have hair. */
+  hairColors?: Array<string>;
+  /** Common skin colors for this species, null if this species does not typically
+have skin. */
+  skinColors?: Array<string>;
+  /** The language commonly spoken by this species. */
+  language?: string;
+  /** A planet that this species originates from. */
+  homeworld?: Planet;
+  personConnection?: SpeciesPeopleConnection;
+  filmConnection?: SpeciesFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: any;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesPeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesPeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesPeopleEdge {
-    __typename: string;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesPeopleEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PersonStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PersonStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A single transport craft that has hyperdrive capability.
-  */
-  export interface IStarship {
-    __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    hyperdriveRating: number;
-    MGLT: any;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A single transport craft that has hyperdrive capability.
+*/
+export type Starship = {
+  __typename: string;
+  /** The name of this starship. The common name, such as "Death Star". */
+  name?: string;
+  /** The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+Orbital Battle Station". */
+  model?: string;
+  /** The class of this starship, such as "Starfighter" or "Deep Space Mobile
+Battlestation" */
+  starshipClass?: string;
+  /** The manufacturers of this starship. */
+  manufacturers?: Array<string>;
+  /** The cost of this starship new, in galactic credits. */
+  costInCredits?: number;
+  /** The length of this starship in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this starship. */
+  crew?: string;
+  /** The number of non-essential people this starship can transport. */
+  passengers?: string;
+  /** The maximum speed of this starship in atmosphere. null if this starship is
+incapable of atmosphering flight. */
+  maxAtmospheringSpeed?: number;
+  /** The class of this starships hyperdrive. */
+  hyperdriveRating?: number;
+  /** The Maximum number of Megalights this starship can travel in a standard hour.
+A "Megalight" is a standard unit of distance and has never been defined before
+within the Star Wars universe. This figure is only really useful for measuring
+the difference in speed of starships. We can assume it is similar to AU, the
+distance between our Sun (Sol) and Earth. */
+  MGLT?: number;
+  /** The maximum number of kilograms that this starship can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this starship can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: StarshipPilotsConnection;
+  filmConnection?: StarshipFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipPilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: any;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipPilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipPilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipPilotsEdge {
-    __typename: string;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type StarshipPilotsEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type StarshipFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PersonVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PersonVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A single transport craft that does not have hyperdrive capability
-  */
-  export interface IVehicle {
-    __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: any;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    cargoCapacity: any;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
+/**
+  description: A single transport craft that does not have hyperdrive capability
+*/
+export type Vehicle = {
+  __typename: string;
+  /** The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+bike". */
+  name?: string;
+  /** The model or official name of this vehicle. Such as "All-Terrain Attack
+Transport". */
+  model?: string;
+  /** The class of this vehicle, such as "Wheeled" or "Repulsorcraft". */
+  vehicleClass?: string;
+  /** The manufacturers of this vehicle. */
+  manufacturers?: Array<string>;
+  /** The cost of this vehicle new, in Galactic Credits. */
+  costInCredits?: number;
+  /** The length of this vehicle in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this vehicle. */
+  crew?: string;
+  /** The number of non-essential people this vehicle can transport. */
+  passengers?: string;
+  /** The maximum speed of this vehicle in atmosphere. */
+  maxAtmospheringSpeed?: number;
+  /** The maximum number of kilograms that this vehicle can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this vehicle can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: VehiclePilotsConnection;
+  filmConnection?: VehicleFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclePilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: any;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclePilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclePilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclePilotsEdge {
-    __typename: string;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type VehiclePilotsEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehicleFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type VehicleFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehicleFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehicleFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type VehicleFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PlanetFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmSpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmSpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmSpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmSpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmSpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmCharactersConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: any;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmCharactersConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmCharactersEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmCharactersEdge {
-    __typename: string;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmCharactersEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type FilmPlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmPlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type FilmPlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: any;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPeopleEdge {
-    __typename: string;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PeopleEdge = {
+  __typename: string;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type PlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
+/**
+  description: An edge in a connection.
+*/
+export type StarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
 
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
 
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }`
+/**
+  description: An edge in a connection.
+*/
+export type VehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}

--- a/test/data/starWarsModule.js
+++ b/test/data/starWarsModule.js
@@ -1,642 +1,1039 @@
-module.exports = `// graphql typescript definitions
-
-declare module StarWars {
-  export interface GraphQLResponseRoot {
-    data?: IRoot;
-    errors?: Array<GraphQLResponseError>;
-  }
-
-  export interface GraphQLResponseError {
-    message: string;            // Required for all errors
-    locations?: Array<GraphQLResponseErrorLocation>;
-    [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
-  }
-
-  export interface GraphQLResponseErrorLocation {
-    line: number;
-    column: number;
-  }
-
-  /*
-    description: null
-  */
-  export interface IRoot {
-    __typename: string;
-    allFilms: IFilmsConnection;
-    film: IFilm;
-    allPeople: IPeopleConnection;
-    person: IPerson;
-    allPlanets: IPlanetsConnection;
-    planet: IPlanet;
-    allSpecies: ISpeciesConnection;
-    species: ISpecies;
-    allStarships: IStarshipsConnection;
-    starship: IStarship;
-    allVehicles: IVehiclesConnection;
-    vehicle: IVehicle;
-    node: Node;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: Information about pagination in a connection.
-  */
-  export interface IPageInfo {
-    __typename: string;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
-    startCursor: string;
-    endCursor: string;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A single film.
-  */
-  export interface IFilm {
-    __typename: string;
-    title: string;
-    episodeID: any;
-    openingCrawl: string;
-    director: string;
-    producers: Array<string>;
-    releaseDate: string;
-    speciesConnection: IFilmSpeciesConnection;
-    starshipConnection: IFilmStarshipsConnection;
-    vehicleConnection: IFilmVehiclesConnection;
-    characterConnection: IFilmCharactersConnection;
-    planetConnection: IFilmPlanetsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: An object with an ID
-  */
-  export type Node = IPlanet | ISpecies | IStarship | IVehicle | IPerson | IFilm;
-
-  /*
-    description: An object with an ID
-  */
-  export interface INode extends IPlanet, ISpecies, IStarship, IVehicle, IPerson, IFilm {
-    __typename: string;
-    id: string;
-  }
-
-  /*
-    description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
-0 ABY.
-  */
-  export interface IPlanet {
-    __typename: string;
-    name: string;
-    diameter: any;
-    rotationPeriod: any;
-    orbitalPeriod: any;
-    gravity: string;
-    population: any;
-    climates: Array<string>;
-    terrains: Array<string>;
-    surfaceWater: number;
-    residentConnection: IPlanetResidentsConnection;
-    filmConnection: IPlanetFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetResidentsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetResidentsEdge>;
-    totalCount: any;
-    residents: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetResidentsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: An individual person or character within the Star Wars universe.
-  */
-  export interface IPerson {
-    __typename: string;
-    name: string;
-    birthYear: string;
-    eyeColor: string;
-    gender: string;
-    hairColor: string;
-    height: any;
-    mass: any;
-    skinColor: string;
-    homeworld: IPlanet;
-    filmConnection: IPersonFilmsConnection;
-    species: ISpecies;
-    starshipConnection: IPersonStarshipsConnection;
-    vehicleConnection: IPersonVehiclesConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A type of person or character within the Star Wars Universe.
-  */
-  export interface ISpecies {
-    __typename: string;
-    name: string;
-    classification: string;
-    designation: string;
-    averageHeight: number;
-    averageLifespan: any;
-    eyeColors: Array<string>;
-    hairColors: Array<string>;
-    skinColors: Array<string>;
-    language: string;
-    homeworld: IPlanet;
-    personConnection: ISpeciesPeopleConnection;
-    filmConnection: ISpeciesFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesPeopleEdge>;
-    totalCount: any;
-    people: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesPeopleEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A single transport craft that has hyperdrive capability.
-  */
-  export interface IStarship {
-    __typename: string;
-    name: string;
-    model: string;
-    starshipClass: string;
-    manufacturers: Array<string>;
-    costInCredits: number;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    hyperdriveRating: number;
-    MGLT: any;
-    cargoCapacity: number;
-    consumables: string;
-    pilotConnection: IStarshipPilotsConnection;
-    filmConnection: IStarshipFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipPilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipPilotsEdge>;
-    totalCount: any;
-    pilots: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipPilotsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPersonVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPersonVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPersonVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
-
-  /*
-    description: A single transport craft that does not have hyperdrive capability
-  */
-  export interface IVehicle {
-    __typename: string;
-    name: string;
-    model: string;
-    vehicleClass: string;
-    manufacturers: Array<string>;
-    costInCredits: any;
-    length: number;
-    crew: string;
-    passengers: string;
-    maxAtmospheringSpeed: any;
-    cargoCapacity: any;
-    consumables: string;
-    pilotConnection: IVehiclePilotsConnection;
-    filmConnection: IVehicleFilmsConnection;
-    created: string;
-    edited: string;
-    id: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclePilotsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclePilotsEdge>;
-    totalCount: any;
-    pilots: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclePilotsEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehicleFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehicleFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehicleFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetFilmsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetFilmsEdge>;
-    totalCount: any;
-    films: Array<IFilm>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetFilmsEdge {
-    __typename: string;
-    node: IFilm;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmSpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmSpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmSpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmCharactersConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmCharactersEdge>;
-    totalCount: any;
-    characters: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmCharactersEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IFilmPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IFilmPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IFilmPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPeopleConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPeopleEdge>;
-    totalCount: any;
-    people: Array<IPerson>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPeopleEdge {
-    __typename: string;
-    node: IPerson;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IPlanetsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IPlanetsEdge>;
-    totalCount: any;
-    planets: Array<IPlanet>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IPlanetsEdge {
-    __typename: string;
-    node: IPlanet;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface ISpeciesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<ISpeciesEdge>;
-    totalCount: any;
-    species: Array<ISpecies>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface ISpeciesEdge {
-    __typename: string;
-    node: ISpecies;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IStarshipsConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IStarshipsEdge>;
-    totalCount: any;
-    starships: Array<IStarship>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IStarshipsEdge {
-    __typename: string;
-    node: IStarship;
-    cursor: string;
-  }
-
-  /*
-    description: A connection to a list of items.
-  */
-  export interface IVehiclesConnection {
-    __typename: string;
-    pageInfo: IPageInfo;
-    edges: Array<IVehiclesEdge>;
-    totalCount: any;
-    vehicles: Array<IVehicle>;
-  }
-
-  /*
-    description: An edge in a connection.
-  */
-  export interface IVehiclesEdge {
-    __typename: string;
-    node: IVehicle;
-    cursor: string;
-  }
+// @flow
+// graphql flow definitions
+export type GraphQLResponseRoot = {
+  data?: Root;
+  errors?: Array<GraphQLResponseError>;
 }
 
-export default StarWars;
-`
+export type GraphQLResponseError = {
+  message: string;            // Required for all errors
+  locations?: Array<GraphQLResponseErrorLocation>;
+  [propName: string]: any;    // 7.2.2 says 'GraphQL servers may provide additional entries to error'
+}
+
+export type GraphQLResponseErrorLocation = {
+  line: number;
+  column: number;
+}
+
+export type Root = {
+  __typename: string;
+  allFilms?: FilmsConnection;
+  film?: Film;
+  allPeople?: PeopleConnection;
+  person?: Person;
+  allPlanets?: PlanetsConnection;
+  planet?: Planet;
+  allSpecies?: SpeciesConnection;
+  species?: Species;
+  allStarships?: StarshipsConnection;
+  starship?: Starship;
+  allVehicles?: VehiclesConnection;
+  vehicle?: Vehicle;
+  /** Fetches an object given its ID */
+  node?: Node;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: Information about pagination in a connection.
+*/
+export type PageInfo = {
+  __typename: string;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: boolean;
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: boolean;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: string;
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: string;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single film.
+*/
+export type Film = {
+  __typename: string;
+  /** The title of this film. */
+  title?: string;
+  /** The episode number of this film. */
+  episodeID?: number;
+  /** The opening paragraphs at the beginning of this film. */
+  openingCrawl?: string;
+  /** The name of the director of this film. */
+  director?: string;
+  /** The name(s) of the producer(s) of this film. */
+  producers?: Array<string>;
+  /** The ISO 8601 date format of film release at original creator country. */
+  releaseDate?: string;
+  speciesConnection?: FilmSpeciesConnection;
+  starshipConnection?: FilmStarshipsConnection;
+  vehicleConnection?: FilmVehiclesConnection;
+  characterConnection?: FilmCharactersConnection;
+  planetConnection?: FilmPlanetsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: An object with an ID
+*/
+export type Node = Planet | Species | Starship | Vehicle | Person | Film;
+
+/**
+  description: A large mass, planet or planetoid in the Star Wars Universe, at the time of
+0 ABY.
+*/
+export type Planet = {
+  __typename: string;
+  /** The name of this planet. */
+  name?: string;
+  /** The diameter of this planet in kilometers. */
+  diameter?: number;
+  /** The number of standard hours it takes for this planet to complete a single
+rotation on its axis. */
+  rotationPeriod?: number;
+  /** The number of standard days it takes for this planet to complete a single orbit
+of its local star. */
+  orbitalPeriod?: number;
+  /** A number denoting the gravity of this planet, where "1" is normal or 1 standard
+G. "2" is twice or 2 standard Gs. "0.5" is half or 0.5 standard Gs. */
+  gravity?: string;
+  /** The average population of sentient beings inhabiting this planet. */
+  population?: number;
+  /** The climates of this planet. */
+  climates?: Array<string>;
+  /** The terrains of this planet. */
+  terrains?: Array<string>;
+  /** The percentage of the planet surface that is naturally occuring water or bodies
+of water. */
+  surfaceWater?: number;
+  residentConnection?: PlanetResidentsConnection;
+  filmConnection?: PlanetFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetResidentsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetResidentsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  residents?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetResidentsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: An individual person or character within the Star Wars universe.
+*/
+export type Person = {
+  __typename: string;
+  /** The name of this person. */
+  name?: string;
+  /** The birth year of the person, using the in-universe standard of BBY or ABY -
+Before the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is
+a battle that occurs at the end of Star Wars episode IV: A New Hope. */
+  birthYear?: string;
+  /** The eye color of this person. Will be "unknown" if not known or "n/a" if the
+person does not have an eye. */
+  eyeColor?: string;
+  /** The gender of this person. Either "Male", "Female" or "unknown",
+"n/a" if the person does not have a gender. */
+  gender?: string;
+  /** The hair color of this person. Will be "unknown" if not known or "n/a" if the
+person does not have hair. */
+  hairColor?: string;
+  /** The height of the person in centimeters. */
+  height?: number;
+  /** The mass of the person in kilograms. */
+  mass?: number;
+  /** The skin color of this person. */
+  skinColor?: string;
+  /** A planet that this person was born on or inhabits. */
+  homeworld?: Planet;
+  filmConnection?: PersonFilmsConnection;
+  /** The species that this person belongs to, or null if unknown. */
+  species?: Species;
+  starshipConnection?: PersonStarshipsConnection;
+  vehicleConnection?: PersonVehiclesConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A type of person or character within the Star Wars Universe.
+*/
+export type Species = {
+  __typename: string;
+  /** The name of this species. */
+  name?: string;
+  /** The classification of this species, such as "mammal" or "reptile". */
+  classification?: string;
+  /** The designation of this species, such as "sentient". */
+  designation?: string;
+  /** The average height of this species in centimeters. */
+  averageHeight?: number;
+  /** The average lifespan of this species in years. */
+  averageLifespan?: number;
+  /** Common eye colors for this species, null if this species does not typically
+have eyes. */
+  eyeColors?: Array<string>;
+  /** Common hair colors for this species, null if this species does not typically
+have hair. */
+  hairColors?: Array<string>;
+  /** Common skin colors for this species, null if this species does not typically
+have skin. */
+  skinColors?: Array<string>;
+  /** The language commonly spoken by this species. */
+  language?: string;
+  /** A planet that this species originates from. */
+  homeworld?: Planet;
+  personConnection?: SpeciesPeopleConnection;
+  filmConnection?: SpeciesFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesPeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesPeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  people?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesPeopleEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single transport craft that has hyperdrive capability.
+*/
+export type Starship = {
+  __typename: string;
+  /** The name of this starship. The common name, such as "Death Star". */
+  name?: string;
+  /** The model or official name of this starship. Such as "T-65 X-wing" or "DS-1
+Orbital Battle Station". */
+  model?: string;
+  /** The class of this starship, such as "Starfighter" or "Deep Space Mobile
+Battlestation" */
+  starshipClass?: string;
+  /** The manufacturers of this starship. */
+  manufacturers?: Array<string>;
+  /** The cost of this starship new, in galactic credits. */
+  costInCredits?: number;
+  /** The length of this starship in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this starship. */
+  crew?: string;
+  /** The number of non-essential people this starship can transport. */
+  passengers?: string;
+  /** The maximum speed of this starship in atmosphere. null if this starship is
+incapable of atmosphering flight. */
+  maxAtmospheringSpeed?: number;
+  /** The class of this starships hyperdrive. */
+  hyperdriveRating?: number;
+  /** The Maximum number of Megalights this starship can travel in a standard hour.
+A "Megalight" is a standard unit of distance and has never been defined before
+within the Star Wars universe. This figure is only really useful for measuring
+the difference in speed of starships. We can assume it is similar to AU, the
+distance between our Sun (Sol) and Earth. */
+  MGLT?: number;
+  /** The maximum number of kilograms that this starship can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this starship can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: StarshipPilotsConnection;
+  filmConnection?: StarshipFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipPilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipPilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  pilots?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipPilotsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PersonVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PersonVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PersonVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A single transport craft that does not have hyperdrive capability
+*/
+export type Vehicle = {
+  __typename: string;
+  /** The name of this vehicle. The common name, such as "Sand Crawler" or "Speeder
+bike". */
+  name?: string;
+  /** The model or official name of this vehicle. Such as "All-Terrain Attack
+Transport". */
+  model?: string;
+  /** The class of this vehicle, such as "Wheeled" or "Repulsorcraft". */
+  vehicleClass?: string;
+  /** The manufacturers of this vehicle. */
+  manufacturers?: Array<string>;
+  /** The cost of this vehicle new, in Galactic Credits. */
+  costInCredits?: number;
+  /** The length of this vehicle in meters. */
+  length?: number;
+  /** The number of personnel needed to run or pilot this vehicle. */
+  crew?: string;
+  /** The number of non-essential people this vehicle can transport. */
+  passengers?: string;
+  /** The maximum speed of this vehicle in atmosphere. */
+  maxAtmospheringSpeed?: number;
+  /** The maximum number of kilograms that this vehicle can transport. */
+  cargoCapacity?: number;
+  /** The maximum length of time that this vehicle can provide consumables for its
+entire crew without having to resupply. */
+  consumables?: string;
+  pilotConnection?: VehiclePilotsConnection;
+  filmConnection?: VehicleFilmsConnection;
+  /** The ISO 8601 date format of the time that this resource was created. */
+  created?: string;
+  /** The ISO 8601 date format of the time that this resource was edited. */
+  edited?: string;
+  /** The ID of an object */
+  id: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclePilotsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclePilotsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  pilots?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehiclePilotsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehicleFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehicleFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehicleFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetFilmsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetFilmsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  films?: Array<Film>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetFilmsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Film;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmSpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmSpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmSpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmStarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmStarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmStarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmVehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmVehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmVehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmCharactersConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmCharactersEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  characters?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmCharactersEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type FilmPlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<FilmPlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type FilmPlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PeopleConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PeopleEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  people?: Array<Person>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PeopleEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Person;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type PlanetsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<PlanetsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  planets?: Array<Planet>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type PlanetsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Planet;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type SpeciesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<SpeciesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  species?: Array<Species>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type SpeciesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Species;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type StarshipsConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<StarshipsEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  starships?: Array<Starship>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type StarshipsEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Starship;
+  /** A cursor for use in pagination */
+  cursor: string;
+}
+
+/**
+  description: A connection to a list of items.
+*/
+export type VehiclesConnection = {
+  __typename: string;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Information to aid in pagination. */
+  edges?: Array<VehiclesEdge>;
+  /** A count of the total number of objects in this connection, ignoring pagination.
+This allows a client to fetch the first five objects by passing "5" as the
+argument to "first", then fetch the total count so it could display "5 of 83",
+for example. */
+  totalCount?: number;
+  /** A list of all of the objects returned in the connection. This is a convenience
+field provided for quickly exploring the API; rather than querying for
+"{ edges { node } }" when no edge data is needed, this field can be be used
+instead. Note that when clients like Relay need to fetch the "cursor" field on
+the edge to enable efficient pagination, this shortcut cannot be used, and the
+full "{ edges { node } }" version should be used instead. */
+  vehicles?: Array<Vehicle>;
+}
+
+/**
+  description: An edge in a connection.
+*/
+export type VehiclesEdge = {
+  __typename: string;
+  /** The item at the end of the edge */
+  node?: Vehicle;
+  /** A cursor for use in pagination */
+  cursor: string;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,66 +1,73 @@
 'use strict';
 const expect       = require('chai').expect;
+
 let interfaceUtils = require('../util/interface');
 let moduleUtils    = require('../util/module');
-let expectedModule = require('./data/expectedModule');
+
 let schema         = require('./data/starWarsSchema');
 let enumSchema     = require('./data/enumSchema');
-let expectedInterfaces = require('./data/expectedInterfaces');
 
-describe('gql2ts', () => {
+function fixture(name) {
+  return fs.readFileSync(`./test/data/${name}.js`).toString()
+}
+
+const fs = require("fs")
+
+describe('gql2flow', () => {
   describe('interfaces', () => {
-    it('correctly translates the star wars schema into typescript defs', () => {
+    it('correctly translates the star wars schema into flow defs', () => {
       let actual = interfaceUtils.schemaToInterfaces(schema, { ignoredTypes: [] });
-
-      expect(actual).to.equal(expectedInterfaces);
+      
+      // fs.writeFileSync('./test/data/expectedInterfaces.js', actual)
+      expect(actual).to.equal(fixture("expectedInterfaces"));
     });
 
     it('correctly ignores types', () => {
       let actual = interfaceUtils.schemaToInterfaces(schema, { ignoredTypes: ['Person'] });
-      let ignoredPerson = require('./data/ignoredPersonInterfaces');
-      expect(actual).to.equal(ignoredPerson);
+
+      // fs.writeFileSync('./test/data/ignoredPersonInterfaces.js', actual)
+      expect(actual).to.equal(fixture("ignoredPersonInterfaces"));
     });
 
     it('correctly translates enums', () => {
       let actual = interfaceUtils.schemaToInterfaces(enumSchema, { ignoredTypes: [] });
-      let enumInterfaces = require('./data/expectedEnumInterfaces');
-      expect(actual).to.equal(enumInterfaces);
+
+      // fs.writeFileSync('./test/data/expectedEnumInterfaces.js', actual)
+      expect(actual).to.equal(fixture("expectedEnumInterfaces"));
     });
   });
-
 
   describe('modules', () => {
     it('correctly generates Modules', () => {
       let interfaces = interfaceUtils.schemaToInterfaces(schema, { ignoredTypes: [] });
       let module = moduleUtils.generateModule('GQL', interfaces);
-      expect(module).to.equal(expectedModule);
+
+      // fs.writeFileSync('./test/data/expectedModule.js', module)
+      expect(module).to.equal(fixture("expectedModule"));
     });
 
     it('correctly uses a custom namespace', () => {
       let interfaces = interfaceUtils.schemaToInterfaces(schema, { ignoredTypes: [] });
       let module = moduleUtils.generateModule('StarWars', interfaces);
 
-      let swModule = require('./data/starWarsModule');
-
-      expect(module).to.equal(swModule);
+      // fs.writeFileSync('./test/data/starWarsModule.js', module)
+      expect(module).to.equal(fixture("starWarsModule"));
     });
 
     it('correctly uses a namespace and ignores', () => {
       let interfaces = interfaceUtils.schemaToInterfaces(schema, { ignoredTypes: ['Person'] });
       let module = moduleUtils.generateModule('StarWars', interfaces);
 
-      let swModule = require('./data/ignoredPerson');
-
-      expect(module).to.equal(swModule);
+      // fs.writeFileSync('./test/data/ignoredPerson.js', module)
+      expect(module).to.equal(fixture("ignoredPerson"));
     });
 
     it('correctly translates enums', () => {
       let interfaces = interfaceUtils.schemaToInterfaces(enumSchema, { ignoredTypes: [] });
       let module = moduleUtils.generateModule('GQL', interfaces);
 
-      let enumModule = require('./data/expectedEnum');
-
-      expect(module).to.equal(enumModule);
+      // fs.writeFileSync('./test/data/expectedEnum.js', module)
+      expect(module).to.equal(fixture("expectedEnum"));
     });
   });
 });

--- a/util/interface.js
+++ b/util/interface.js
@@ -34,14 +34,14 @@ export type GraphQLResponseErrorLocation = {
 
 const generateTypeName = name => `${name}`;
 
-const generateTypeDeclaration = (description, name, possibleTypes) => `${description && `/*
+const generateTypeDeclaration = (description, name, possibleTypes) => `${description && `/**
   description: ${description}
 */`}
 export type ${name} = ${possibleTypes};`;
 
 const typeNameDeclaration = '__typename: string;\n'
 
-const generateInterfaceDeclaration = (description, declaration, fields, additionalInfo, isInput) => `${additionalInfo}${description ? `/*
+const generateInterfaceDeclaration = (description, declaration, fields, additionalInfo, isInput) => `${additionalInfo}${description ? `/**
   description: ${description}
 */\n` : ''}export type ${declaration} = {
   ${isInput ? '' : typeNameDeclaration}${fields}
@@ -49,7 +49,7 @@ const generateInterfaceDeclaration = (description, declaration, fields, addition
 
 const generateEnumName = name => `${name}Enum`;
 
-const generateEnumDeclaration = (description, name, enumValues) => `${description && `/*
+const generateEnumDeclaration = (description, name, enumValues) => `${description && `/**
 description: ${description}
 */`}
 export type ${generateEnumName(name)} = ${enumValues.join(' | ')};`;
@@ -102,9 +102,9 @@ const fieldToDefinition = (field, isInput) => {
   } else {
     fieldDef = `${field.name}: ${interfaceName}`;
   }
-  
-  const description = field.description !== null ? `/* ${field.description} */\n` : ``
 
+  const description = field.description !== null ? `  /** ${field.description} */\n` : ``
+  
   return `${description}  ${fieldDef};`;
 }
 

--- a/util/interface.js
+++ b/util/interface.js
@@ -102,8 +102,10 @@ const fieldToDefinition = (field, isInput) => {
   } else {
     fieldDef = `${field.name}: ${interfaceName}`;
   }
+  
+  const description = field.description !== null ? `/* ${field.description} */\n` : ``
 
-  return `  ${fieldDef};`;
+  return `${description}  ${fieldDef};`;
 }
 
 const findRootType = type => {


### PR DESCRIPTION
The PR itself it hefty only because the test file fixtures have changed. 

Fixes #5 

---

Makes it feasible for editor's like VS Code to show the description inline

![screen shot 2016-12-27 at 1 40 40 pm](https://cloud.githubusercontent.com/assets/49038/21505953/2adf8568-cc3a-11e6-8955-22856a24ab6f.png)
