### PR TITLE
Ignore property types 

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,12 @@ program
     []
   )
   .option(
+    '--ignored-property-types <ignoredPropertyTypes>',
+    'property types to ignore (comma delimited)',
+    v => v.split(','),
+    []
+  )
+  .option(
     '-w --whitelist <whitelist>',
     'names of types to whitelist (comma delimited)',
     v => v.split(','),

--- a/util/interface.js
+++ b/util/interface.js
@@ -121,7 +121,7 @@ ${fields}
     return findRootType(type.ofType);
   };
 
-  const filterField = (field, ignoredTypes) => {
+  const filterField = (field, ignoredTypes, ignoredPropertyTypes) => {
     let nestedType = findRootType(field.type);
     return !ignoredTypes.includes(nestedType.name);
   };
@@ -143,7 +143,7 @@ ${fields}
     let f = isInput ? type.inputFields : type.fields || [];
 
     let fields = f
-      .filter(field => filterField(field, ignoredTypes))
+      .filter(field => filterField(field, ignoredPropertyTypes))
       .map(field => fieldToDefinition(field))
       .filter(field => field)
       .join('\n');
@@ -191,7 +191,7 @@ ${fields}
 
         return options.whitelist.includes(type.name);
       })
-      .map(type => typeToInterface(type, options.ignoredTypes)) // convert to interface
+      .map(type => typeToInterface(type, options.ignoredTypes, options.ignoredPropertyTypes)) // convert to interface
       .filter(type => type); // remove empty ones
 
     return interfaces


### PR DESCRIPTION
With these changes you can now ignore properties that have specific types instead of the whole type.

I'm not that familiar with the spec, so I might have missed some use cases. This just works well enough for me since I'm just using regular ol' types.

E.g. 
schema
```
type Role {
  name: String!
}

type User {
  email: String!,
  roles: [Role]!
}
```

gql2flow --ignore-property-types "Role"
```
type User = {
  email: string
}

type Role = {
  name: string
}
```

gql2flow
```
type User = {
  email: string,
  roles: Array<Role>
}

type Role = {
  name: string
}
```

The reason is that I needed these types to annotate my resolver functions in apollo.