### PR TITLE
Add headers support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,14 +10,17 @@ Usage: gql2flow [options] <schema.json>
 
 Options:
 
-  -h, --help                         output usage information
-  -V, --version                      output the version number
-  -o --output-file [outputFile]      name for output file, defaults to graphql-export.flow.js
-  -m --module-name [moduleName]      name for the export module. Types are not wrapped in a module if this is not set
-  -i --ignored-types <ignoredTypes>  names of types to ignore (comma delimited)
-  -w --whitelist <whitelist>         names of types to whitelist (comma delimited)
-  --null-keys                        adds a '?' to all keys
-  --null-values                      adds a '?' to all values
+    -V, --version                      output the version number
+    -e --export                        use export rather than declare to define types
+    -o --output-file [outputFile]      name for ouput file, defaults to graphql-export.flow.js
+    --null-keys [nullKeys]             makes all keys nullable
+    --null-values [nullValues]         makes all values nullable
+    --headers [headers]                Headers to add to the request when fetching from a server
+    -m --module-name [moduleName]      name for the export module. Types are not wrapped in a module if this is not set
+    -t --typeMap <typeSpec>            Define custom scalar types where typeSpec is <graphql type>:<flow type>
+    -i --ignored-types <ignoredTypes>  names of types to ignore (comma delimited)
+    -w --whitelist <whitelist>         names of types to whitelist (comma delimited)
+    -h, --help                         output usage information
 ```
 
 ## Examples
@@ -25,6 +28,11 @@ Options:
 #### Fetching from a server
 ```shell
 gql2flow https://api.github.com/graphql
+```
+
+##### With custom headers
+```shell
+gql2flow https://api.github.com/graphql --headers "Authorization: bearer <TOKEN>; Version: 1.1"
 ```
 
 #### From a json schema

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ const moduleUtils = require('./util/module');
 // Fetch utils
 const fetchUtils = require('./util/fetcher');
 
+// Header utils
+const getHeaders = require('./util/headers');
+
 program
   .version('0.4.4')
   .usage('[options] <schema.json>')
@@ -27,6 +30,11 @@ program
   )
   .option('--null-keys [nullKeys]', 'makes all keys nullable', false)
   .option('--null-values [nullValues]', 'makes all values nullable', false)
+  .option(
+    '--headers [headers]',
+    'Headers to add to the request when fetching from a server',
+    false
+  )
   .option(
     '-m --module-name [moduleName]',
     'name for the export module. Types are not wrapped in a module if this is not set',
@@ -62,7 +70,8 @@ program
   .action((path, options) => {
     const getSchema = new Promise((resolve, reject) => {
       if (isUrl(path)) {
-        fetchUtils.fetchWithIntrospection(path, (err, schema) => {
+        const headers = getHeaders(options);
+        fetchUtils.fetchWithIntrospection(path, headers, (err, schema) => {
           if (err) {
             reject(err);
           } else if (!schema.data) {

--- a/util/fetcher.js
+++ b/util/fetcher.js
@@ -3,22 +3,24 @@ const fs = require('fs');
 const {
   buildClientSchema,
   introspectionQuery,
-  printSchema,
+  printSchema
 } = require('graphql/utilities');
 
+const defaultHeaders = {
+  Accept: 'application/json',
+  'Content-Type': 'application/json'
+};
+
 module.exports = {
-  fetchWithIntrospection: (url, callback) => {
+  fetchWithIntrospection: (url, headers, callback) => {
     console.log('Fetching', url);
     fetch(url, {
       method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ query: introspectionQuery }),
+      headers: Object.assign(defaultHeaders, headers),
+      body: JSON.stringify({ query: introspectionQuery })
     })
       .then(res => res.json())
       .then(schemaa => callback(null, schemaa))
       .catch(err => callback(err));
-  },
+  }
 };

--- a/util/headers.js
+++ b/util/headers.js
@@ -1,0 +1,11 @@
+module.exports = function getHeaders(options) {
+  return !!options.headers
+    ? options.headers.split(';').reduce((acc, pair) => {
+        const [key, value] = pair.split(':');
+        if (key.trim() === '' || value.trim() === '') return acc;
+
+        acc[key.trim()] = value.trim();
+        return acc;
+      }, {})
+    : {};
+};


### PR DESCRIPTION
I'm switching from using a GraphQL based service to my own CMS installation, and it's security requirements are different, so I needed custom headers :). Some notes on this PR:

- I'm assuming Object.assign, array destructuring and arrow function support, so Node 6+. Since current LTS is 6, and it'll soon be Node 8, this seems like a reasonable assumption to me. If you disagree, please let me know and I'll refactor to ES5.
- The output of `--help` for README.md is differently sorted than yours... No idea why, wasn't sure whether you'd like to maintain the old order...
- The changelog appears to be out of date, so I didn't bump versions anywhere.

Furthermore, I think you're reaching the point where it might be good to add some integration-level testing (mocking out the network / fs), and some convention etc... Would you like me to add eslint, editorconfig, prettier and basic set up for more extensive testing?