### PR TITLE
fix module declaration syntax

### DIFF
--- a/util/interface.js
+++ b/util/interface.js
@@ -2,7 +2,9 @@
 require('./polyfill');
 
 const generateTypes = (schema, options) => {
-  const exportOrDeclare = (options.export || options.moduleName) ? 'export' : 'declare';
+  let exportOrDeclare = 'declare';
+  if (options.export) exportOrDeclare = 'export';
+  if (options.moduleName) exportOrDeclare = 'declare export';
 
   const generateRootDataName = schema => {
     let rootNamespaces = [];


### PR DESCRIPTION
when using the `moduleName` flag, the inner declarations were as `export` but need to be `declare export`

https://flow.org/en/docs/libdefs/creation/#declaring-a-global-type-a-classtoc-idtoc-declaring-a-global-type-hreftoc-declaring-a-global-typea