### PR TITLE
Module no longer forces export instead of declare

### DIFF
--- a/util/interface.js
+++ b/util/interface.js
@@ -2,7 +2,7 @@
 require('./polyfill');
 
 const generateTypes = (schema, options) => {
-  const exportOrDeclare = (options.export || options.moduleName) ? 'export' : 'declare';
+  const exportOrDeclare = (options.export) ? 'export' : 'declare';
 
   const generateRootDataName = schema => {
     let rootNamespaces = [];


### PR DESCRIPTION
Ran into an issue where I needed child elements of a module to use declare. Removed the conditional check for moduleName in the export/declare toggle.