### PR TITLE
docs: deprecated => unmaintained

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-## This project is deprecated, use [gql2ts](https://github.com/avantcredit/gql2ts) instead
+## This project is unmaintained, if you are a TypeScript user, you may use [gql2ts](https://github.com/avantcredit/gql2ts) instead
 
 # GraphQL To Flow Types
 


### PR DESCRIPTION
I don't think it's fair to tell Flow users to use TypeScript if they want to use this project, just tell them this project is not maintained anymore, and point TypeScript users to gql2ts